### PR TITLE
商品出品機能の更新

### DIFF
--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -1,0 +1,17 @@
+$( document ).on('turbolinks:load', function() {
+  $('.k_ir_section__inner--form-input-default').on('change', function(){
+    $('#preview').text('');
+    var $files = $(this).prop('files');
+    var length = $files.length;
+    for (var i = 0; i < length; i++) {
+      var file = $files[i];
+      var reader = new FileReader();
+      reader.onload = function(e) {
+        var src = e.target.result;
+        var img = '<img src="'+ src + '">';
+        $('#preview').append(img);
+      }
+      reader.readAsDataURL(file);
+    }
+  })
+});

--- a/app/assets/stylesheets/_item_regi.scss
+++ b/app/assets/stylesheets/_item_regi.scss
@@ -22,6 +22,13 @@
   width: 100%;
 }
 
+#preview {
+  display: flex;
+  img {
+    width: 20%;
+  }
+}
+
 .k_ir_section {
   height: 100%;
   width: 700px;
@@ -39,7 +46,6 @@
     height: 1333px;
     width: 100%;
     &--form {
-      height: 350px;
       border-bottom: 1px solid #f5f5f5;
       padding: 40px 40px 64px;
       box-sizing: border-box;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,6 +10,9 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
+      params[:images]['image'].each do |i|
+        @image = @item.images.create!(image: i)
+      end
       redirect_to root_path
     else
       render 'items/new'

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -24,7 +24,8 @@
                   .k_ir_section__inner--form-input-content 
                     %p ドラッグアンドドロップ
                     %p またはクリックしてファイルをダウンロード
-              = image.file_field :image, class: 'k_ir_section__inner--form-input-default'
+                = image.file_field :image, multiple: true, name: "images[image][]", class: 'k_ir_section__inner--form-input-default'
+                #preview
             
           .k_ir_section__inner--form2
             .k_ir_section__inner--form2-label


### PR DESCRIPTION
## WHAT
商品出品機能を更新しました。
複数画像(1回で全て)アップロード、選択した画像をプレビューできるようにしました。

## まだできていないところ
- カテゴリー・ブランド・サイズ・都道府県
- 複数回に分けて画像をアップロード
- アップロードした画像を削除
- 画像プレビューの位置
- 画像を1~10枚に制限