### PR TITLE
出品機能　画像関連

### DIFF
--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -5,7 +5,7 @@ $(document).on('turbolinks:load', function() {
   $(document).on('change', 'input[type= "file"]', function(){
     var file = $(this).prop('files')[0];
     image_files.push(file);
-    var reader = new FileReader;
+    var reader = new FileReader();
     
     var img = $('<div class="add_img"><div class="img_area"><img class="image"></div></div>')
     var btn = $('<div class="btn_wrapper"><a class="btn_edit">編集</a><a class="btn_delete">削除</a></div>')

--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -1,4 +1,9 @@
 $(document).on('turbolinks:load', function() {
+  var imagelabel1 = $('.o_image-label1')
+  var imagelabel2 = $('.o_image-label2')
+  var imagezone1 = $('.o_image-zone1-parent')
+  var imagezone2 = $('.o_image-zone2-parent')
+
   var images = [];
   var image_files = [];
 
@@ -8,7 +13,7 @@ $(document).on('turbolinks:load', function() {
     var reader = new FileReader();
     
     var img = $('<div class="add_img"><div class="img_area"><img class="image"></div></div>')
-    var btn = $('<div class="btn_wrapper"><a class="btn_edit">編集</a><a class="btn_delete">削除</a></div>')
+    var btn = $('<div class="btn_wrapper"><a class="btn_delete">削除</a></div>')
     img.append(btn);
     
     reader.onload = function(e) {
@@ -18,15 +23,44 @@ $(document).on('turbolinks:load', function() {
     reader.readAsDataURL(file);
     images.push(img);
     
-    $('#preview').text('');
-    $.each(images, function(i, image){
-      image.data('image', i);
-      $('#preview').append(image);
-    })
+    if (images.length <= 4) {
+      $('#preview1').text('');
+      $.each(images, function(i, image){
+        image.data('image', i);
+        $('#preview1').append(image);
+      })
+      imagelabel1.css({
+        width: `calc(100% - (20% * ${images.length})`
+      })
+    } else if (images.length == 5) {
+      $('#preview1').text('');
+      $.each(images, function(i, image){
+        image.data('image', i);
+        $('#preview1').append(image);
+      })
+      imagelabel1.css({
+        display: "none"
+      })
+      imagezone2.css({
+        display: "block"
+      })
+    } else {
+      var secondrow_images = images.slice(5)
+      $.each(secondrow_images, function(i, image){
+        image.data('image', i + 5);
+        $('#preview2').append(image);
+      })
+      imagelabel2.css({
+        width: `calc(100% - (20% * ${images.length - 5})`
+      })
+    }
+    if (images.length == 10) {
+      imagelabel2.css({
+        display: "none"
+      })
+    }
 
-    var new_image = $(
-      `<input multiple="multiple" name="image[images][]" data-image=${images.length} type="file" id="item_images_attributes_0_image">`
-    );
+    var new_image = $(`<input multiple="multiple" name="image[images][]" data-image=${images.length} type="file" id="item_images_attributes_0_image">`);
     $('.preview-btn').append(new_image);
   })
 
@@ -34,7 +68,61 @@ $(document).on('turbolinks:load', function() {
     var target_image = $(this).parent().parent();
     var target_image_num = target_image.data('image');
     target_image.remove();
+    images.splice(target_image_num, 1);
     image_files.splice(target_image_num, 1);
+
+    if (images.length == 0) {
+      $('input[type="file"]').data('image', 0)
+    }
+
+    if (images.length <= 4) {
+      $('#preview1').text('');
+      $.each(images, function(i, image){
+        image.data('image', i);
+        $('#preview1').append(image);
+      })
+      imagelabel1.css({
+        display: 'block',
+        width: `calc(100% - (20% * ${images.length})`
+      })
+      imagezone2.css({
+        display: 'none'
+      })
+    } else if (images.length == 5) {
+      $('#preview1').text('');
+      $.each(images, function(i, image){
+        image.data('image', i);
+        $('#preview1').append(image);
+      })
+      imagezone1.css({
+        display: 'block'
+      })
+      imagelabel2.css({
+        width: '100%'
+      })
+      imagelabel1.css({
+        display: 'none'
+      })
+      $('#preview2').text('')
+    } else {
+      var firstrow_images = images.slice(0, 5)
+      $('#preview1').text('')
+      $.each(firstrow_images, function(i, image) {
+        image.data('image', i)
+        $('#preview1').append(image)
+      })
+
+      var secondrow_images = images.slice(5)
+      $.each(secondrow_images, function(i, image){
+        image.data('image', i + 5)
+        $('#preview2').append(image)
+        imagelabel2.css({
+          display: 'block',
+          width: `calc(100% - (20% * ${images.length - 5})`
+        })
+      })
+    }
+
   })
 
   $('#new_item').on('submit', function(e) {

--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -1,17 +1,59 @@
-$( document ).on('turbolinks:load', function() {
-  $('.k_ir_section__inner--form-input-default').on('change', function(){
+$(document).on('turbolinks:load', function() {
+  var images = [];
+  var image_files = [];
+
+  $(document).on('change', 'input[type= "file"]', function(){
+    var file = $(this).prop('files')[0];
+    image_files.push(file);
+    var reader = new FileReader;
+    
+    var img = $('<div class="add_img"><div class="img_area"><img class="image"></div></div>')
+    var btn = $('<div class="btn_wrapper"><a class="btn_edit">編集</a><a class="btn_delete">削除</a></div>')
+    img.append(btn);
+    
+    reader.onload = function(e) {
+      img.find('img').attr({ src: e.target.result });
+    };
+    
+    reader.readAsDataURL(file);
+    images.push(img);
+    
     $('#preview').text('');
-    var $files = $(this).prop('files');
-    var length = $files.length;
-    for (var i = 0; i < length; i++) {
-      var file = $files[i];
-      var reader = new FileReader();
-      reader.onload = function(e) {
-        var src = e.target.result;
-        var img = '<img src="'+ src + '">';
-        $('#preview').append(img);
-      }
-      reader.readAsDataURL(file);
-    }
+    $.each(images, function(i, image){
+      image.data('image', i);
+      $('#preview').append(image);
+    })
+
+    var new_image = $(
+      `<input multiple="multiple" name="image[images][]" data-image=${images.length} type="file" id="item_images_attributes_0_image">`
+    );
+    $('.preview-btn').append(new_image);
+  })
+
+  $(document).on('click', '.btn_delete', function(){
+    var target_image = $(this).parent().parent();
+    var target_image_num = target_image.data('image');
+    target_image.remove();
+    image_files.splice(target_image_num, 1);
+  })
+
+  $('#new_item').on('submit', function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    formData.delete('image[images][]');
+    $.each(image_files, function(i, file){
+      formData.append("image[images][]", file)
+    })
+
+    $.ajax({
+      url: '/items',
+      type: 'POST',
+      data: formData,
+      contentType: false,
+      processData: false
+    })
+    .always(function(){
+      $("input[type=submit]").removeAttr("disabled");
+    })
   })
 });

--- a/app/assets/stylesheets/_item_regi.scss
+++ b/app/assets/stylesheets/_item_regi.scss
@@ -18,14 +18,57 @@
 }
 
 .k_ir_wrapper {
-  height: 2150px;
   width: 100%;
 }
 
-#preview {
+.o_image-zone1, .o_image-zone2 {
   display: flex;
   img {
-    width: 20%;
+    width: 110px;
+  }
+}
+
+.o_image-zone2-parent {
+  display: none;
+  margin-top: 10px;
+}
+
+#preview1, #preview2 {
+  display: flex;
+}
+
+.o_image-label1, .o_image-label2 {
+  width: 100%;
+  height: 160px;
+}
+
+.o_file-field {
+  display: none;
+}
+
+.add_img {
+  background: #f5f5f5;
+  border: 1px solid #eee;
+  height: 160px;
+  width: 110px;
+  margin-right: 17px;
+}
+
+.img_area {
+  padding-top: 30px;
+  height: 70%;
+}
+
+.btn_wrapper {
+  height: 30%;
+  text-align: center;
+  margin-top: 10px;
+  a {
+    color: #0099e8;
+    &:hover {
+      opacity: 0.7;
+      text-decoration: underline;
+    }
   }
 }
 
@@ -43,7 +86,7 @@
     border-bottom: 1px solid #f5f5f5;
   }
   &__inner {
-    height: 1333px;
+    height: 100%;
     width: 100%;
     &--form {
       border-bottom: 1px solid #f5f5f5;
@@ -64,21 +107,18 @@
       }
       &-sentence {
         margin: 5px 0;
-
       }
       &-input {
-        height: 200px;
-        width: 100%;
-        margin: 8px auto 0;
+        height: 160px;
+        margin: 0 auto;
         background-color: #f5f5f5;
         border: dashed 1px silver;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         cursor: pointer;
-        &-default {
-          display: none;
-        }
         &-content {
           text-align: center;
-          padding: 70px;
         }
       }
     }
@@ -138,7 +178,6 @@
       }
       &-right {
         width: 60%;
-      
         &-label {
           display: inline;
           font-weight: bold;
@@ -279,7 +318,7 @@
     }
     &--form6 {
       height: 300px;
-      padding: 40px 40px 64px;
+      padding: 40px;
       box-sizing: border-box;
       .k_ir_link {
         text-decoration: none;

--- a/app/assets/stylesheets/_item_regi.scss
+++ b/app/assets/stylesheets/_item_regi.scss
@@ -152,7 +152,7 @@
           font-size: 12px;
           display: inline;
         }
-        &-select {
+        &-select, select {
           width: 100%;
           display: block;
           height: 48px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,13 +10,15 @@ class ItemsController < ApplicationController
   end
 
   def create
+    binding.pry
     @item = Item.new(item_params)
     if @item.save
-      params[:images]['image'].each do |i|
-        @image = @item.images.create!(image: i)
+      params[:image][:images].each do |i|
+        @item.images.create!(image: i)
       end
       redirect_to root_path
     else
+      @item.images.build
       render 'items/new'
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,6 +47,7 @@ class ItemsController < ApplicationController
       :shipping_fee,
       :shipping_date,
       :price,
+      :prefecture_id,
       images_attributes: [:image, :item_id]
       )
       .merge(seller_id: current_user.id).merge(status: 0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,9 +10,8 @@ class ItemsController < ApplicationController
   end
 
   def create
-    binding.pry
     @item = Item.new(item_params)
-    if @item.save
+    if @item.save && params[:image][:images].length != 0
       params[:image][:images].each do |i|
         @item.images.create!(image: i)
       end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,15 +19,33 @@
               最大10枚までアップロードできます
 
             = f.fields_for :images do |image|
-              #preview
-              = image.label :image do
-                .k_ir_section__inner--form-input
-                  .k_ir_section__inner--form-input-content 
-                    %p ドラッグアンドドロップ
-                    %p またはクリックしてファイルをダウンロード
-                = image.file_field :image, multiple: true, name: "image[images][]", class: 'k_ir_section__inner--form-input-default'
-                .preview-btn
-            
+              .o_image-zone1-parent
+                .o_image-zone1
+                  #preview1
+                  .o_image-label1
+                    = image.label :image do
+                      .o_file-field
+                        = image.file_field :image, multiple: true, name: "image[images][]"
+                      .k_ir_section__inner--form-input
+                        .k_ir_section__inner--form-input-content 
+                          %p
+                            ドラッグアンドドロップ
+                            %br
+                            またはクリックしてファイルをダウンロード
+              .o_image-zone2-parent
+                .o_image-zone2
+                  #preview2
+                  .o_image-label2
+                    = image.label :image do
+                      .o_file-field
+                        = image.file_field :image, multiple: true, name: "image[images][]"
+                      .k_ir_section__inner--form-input
+                        .k_ir_section__inner--form-input-content 
+                          %p
+                            ドラッグアンドドロップ
+                            %br
+                            またはクリックしてファイルをダウンロード
+
           .k_ir_section__inner--form2
             .k_ir_section__inner--form2-label
               商品名

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,13 +19,14 @@
               最大10枚までアップロードできます
 
             = f.fields_for :images do |image|
+              #preview
               = image.label :image do
                 .k_ir_section__inner--form-input
                   .k_ir_section__inner--form-input-content 
                     %p ドラッグアンドドロップ
                     %p またはクリックしてファイルをダウンロード
-                = image.file_field :image, multiple: true, name: "images[image][]", class: 'k_ir_section__inner--form-input-default'
-                #preview
+                = image.file_field :image, multiple: true, name: "image[images][]", class: 'k_ir_section__inner--form-input-default'
+                .preview-btn
             
           .k_ir_section__inner--form2
             .k_ir_section__inner--form2-label

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -69,8 +69,7 @@
                 発送元の地域
               .k_ir_section__inner--form3-right-span
                 必須
-              %select{class: "k_ir_section__inner--form3-right-select"}
-                %option ---
+              = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: '---'}
               .k_ir_section__inner--form3-right-label
                 発送までの日数
               .k_ir_section__inner--form3-right-span

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -29,9 +29,7 @@
                       .k_ir_section__inner--form-input
                         .k_ir_section__inner--form-input-content 
                           %p
-                            ドラッグアンドドロップ
-                            %br
-                            またはクリックしてファイルをダウンロード
+                            クリックしてファイルをアップロード
               .o_image-zone2-parent
                 .o_image-zone2
                   #preview2
@@ -42,9 +40,7 @@
                       .k_ir_section__inner--form-input
                         .k_ir_section__inner--form-input-content 
                           %p
-                            ドラッグアンドドロップ
-                            %br
-                            またはクリックしてファイルをダウンロード
+                            クリックしてファイルをアップロード
 
           .k_ir_section__inner--form2
             .k_ir_section__inner--form2-label

--- a/db/migrate/20190730025344_add_prefecture_to_items.rb
+++ b/db/migrate/20190730025344_add_prefecture_to_items.rb
@@ -1,0 +1,5 @@
+class AddPrefectureToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :prefecture_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_27_063242) do
+ActiveRecord::Schema.define(version: 2019_07_30_025344) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_07_27_063242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "seller_id"
+    t.integer "prefecture_id", null: false
     t.index ["name"], name: "index_items_on_name"
     t.index ["seller_id"], name: "index_items_on_seller_id"
   end


### PR DESCRIPTION
## WHAT
出品ページの画像関連機能を改善しました。
- 複数枚アップロードできる。
- アップロードした画像がプレビュー表示される。
- アップロードした画像を1枚ずつ削除できる。
- 画像が0枚だと出品できない。
- 10枚に達するとファイル選択できなくなる。
- 見た目も本家と同じように表示できている。

## まだできていないこと
- 一つのファイル選択画面で複数枚はアップロードできない(1枚ずつ)。
- ドラッグ&ドロップによるアップロードは実装できていない。
- カテゴリー・ブランド・サイズは未実装。