### PR TITLE
商品画像表示 縦横比調整

### DIFF
--- a/app/assets/stylesheets/items/_item_regi.scss
+++ b/app/assets/stylesheets/items/_item_regi.scss
@@ -45,6 +45,7 @@
   img {
     width: 110px;
     height: 85px;
+    object-fit: contain;
   }
 }
 

--- a/app/assets/stylesheets/items/_purchase.scss
+++ b/app/assets/stylesheets/items/_purchase.scss
@@ -42,6 +42,9 @@
     margin: 0;
     &__top {
       display: flex;
+      img{
+        object-fit: contain;
+      }
       &--name{
         width: 240px;
         margin: 0 0 0 16px;

--- a/app/assets/stylesheets/items/searches/_search_result_box.scss
+++ b/app/assets/stylesheets/items/searches/_search_result_box.scss
@@ -28,3 +28,6 @@
     }
   }
 }
+.n_item--image{
+  object-fit: contain;
+}

--- a/app/assets/stylesheets/layouts/_toppage.scss
+++ b/app/assets/stylesheets/layouts/_toppage.scss
@@ -13,6 +13,7 @@
   img {
     height: 350px;
     padding: 0 100px;
+    object-fit: contain;
   }
 }
 
@@ -95,6 +96,7 @@
 
 .o_item--image {
   position: relative;
+  object-fit: contain;
 }
 
 .o_item-soldbadge::before{

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -12,8 +12,8 @@
             = image_tag @image.image.to_s, size: "300x300", class:"o_image"
           - else
             = video_tag @image.image.to_s, size: "300x300", controls: true, autobuffer: true, class:"o_image"
-            - if @item.status == "取引中"
-              .o_image-soldbadge
+          - if @item.status == "取引中"
+            .o_image-soldbadge
           .o_image-sub
             - @images.each do |image|
               - if image.image.content_type.include?('image/')

--- a/app/views/searches/_search_item.html.haml
+++ b/app/views/searches/_search_item.html.haml
@@ -2,6 +2,7 @@
   .n_topitem
     = link_to item_path(search_item.id) do
       .n_item--image.o_item--image
+      
         - if search_item.images.first.image.content_type.include?('image/')
           = image_tag search_item.images.first.image.to_s , height: "160px" , width: "160px", class: "n_item--image"
         - else

--- a/app/views/searches/_search_item.html.haml
+++ b/app/views/searches/_search_item.html.haml
@@ -2,7 +2,6 @@
   .n_topitem
     = link_to item_path(search_item.id) do
       .n_item--image.o_item--image
-      
         - if search_item.images.first.image.content_type.include?('image/')
           = image_tag search_item.images.first.image.to_s , height: "160px" , width: "160px", class: "n_item--image"
         - else


### PR DESCRIPTION
# WHAT
cssでobject-fit: contain;を追加して
画像が枠内に収まるようリサイズ

# WHY
出品商品の画像が縦横に伸びない